### PR TITLE
WIP: Fix type in step 7

### DIFF
--- a/tutorial/07.markdown
+++ b/tutorial/07.markdown
@@ -12,12 +12,12 @@ client at the same time, elements in the head or the tail of the list.
 [RPOP](#help) removes the last element from the list and returns it.
 
 <pre><code>
-    <a href="#run">RPOP friends</a> => "3"
+    <a href="#run">RPOP friends</a> => "Bob"
 </code></pre>
 
-Note that the list now only has four elements:
+Note that the list now only has one element:
 
 <pre><code>
-    <a href="#run">LLEN friends</a> => 4
-    <a href="#run">LRANGE friends 0 -1</a> => 1) "Alice" 2) "Bob" 3) "1" 4) "2"
+    <a href="#run">LLEN friends</a> => 1
+    <a href="#run">LRANGE friends 0 -1</a> => 1) "Alice"
 </code></pre>


### PR DESCRIPTION
Step 7 seems to think that 1 2 3 4 was added to the list, when actually they are added in the next step.
Remove mention of the added numbers and correct the text.